### PR TITLE
docs(configuration-build): add yarn before command

### DIFF
--- a/en/api/configuration-build.md
+++ b/en/api/configuration-build.md
@@ -32,7 +32,7 @@ export default {
 
 <div class="Alert Alert--teal">
 
-**Info:** you can use the command `nuxt build --analyze` or `nuxt build -a` to build your application and launch the bundle analyzer on [http://localhost:8888](http://localhost:8888).
+**Info:** you can use the command `yarn nuxt build --analyze` or `yarn nuxt build -a` to build your application and launch the bundle analyzer on [http://localhost:8888](http://localhost:8888). If you are not using yarn you can run the command with npx.
 
 </div>
 


### PR DESCRIPTION
This command doesn't work with npm or npm run it only works with yarn or npx so I think we need to state which commands it works with. As an npm user I would auto do a npm run command and then think it's broken. Feel free to comment if you prefer that the yarn is not added here and if there is a better way of making it more clear